### PR TITLE
changed from colon to semicolon

### DIFF
--- a/src/main/scala/com/typesafe/zinc/Options.scala
+++ b/src/main/scala/com/typesafe/zinc/Options.scala
@@ -155,7 +155,7 @@ extends ArgumentOption[Map[File, File], Context] {
   }
 
   def parseFilePair(pair: String): Option[(File, File)] = {
-    val p = pair split ':'
+    val p = pair split ';'
     if (p.length == 2) Some((new File(p(0)), new File(p(1)))) else None
   }
 }


### PR DESCRIPTION
Since in windows a colon is a valid character it can't be used as separator. A better one is a semicolon. This change will break the argument: `-analysis-map`
