### PR TITLE
fixed annoying EOFExceptions

### DIFF
--- a/src/main/scala/com/typesafe/zinc/ZincClient.scala
+++ b/src/main/scala/com/typesafe/zinc/ZincClient.scala
@@ -87,32 +87,9 @@ class ZincClient(val address: InetAddress, val port: Int) {
     case _: java.io.IOException => false
   }
 
-  private def filterValidArguments(args: Seq[String]): Seq[String] = {
-    @tailrec
-    def filter(validArgs: Seq[String], args: Seq[String]): Seq[String] = args match {
-      case Seq(x, xs@_*) if x.startsWith("-") =>
-        val (values, tail) = xs span { s => !s.startsWith("-") }
-        if(values.isEmpty)
-          filter(x +: validArgs, xs)
-        else {
-          val validValues = values filterNot { _.trim.isEmpty }
-          if(validValues.isEmpty) {
-            filter(validArgs, tail)
-          } else {
-            filter((x +: validValues).reverse ++: validArgs, tail)
-          }
-        }
-      case Seq(x, xs@_*) if x.trim.isEmpty => filter(validArgs, xs)
-      case Seq(x, xs@_*) => filter(x +: validArgs, xs)
-      case Seq() => validArgs
-    }
-    filter(Seq.empty, args).reverse
-  }
-
   private def sendArguments(args: Seq[String], out: OutputStream): Unit = {
     import ZincClient.Chunk.Argument
-    val validArgs = filterValidArguments(args)
-    validArgs foreach { arg => putChunk(Argument, arg, out) }
+    args foreach { arg => putChunk(Argument, arg, out) }
   }
 
   private def sendCommand(command: String, args: Seq[String], out: OutputStream): Unit = {


### PR DESCRIPTION
While using the Zinc server I saw a few `EOFException`s first thinking that there might be something wrong with the compilation. Looking at the code showed me that there isn't. Still those exceptions are irritating since they are suggesting a problem. They are caused by two issues.
1. Checking if a nailgun server is alive
   Connecting to the nailgun server and immediately disconnecting throws an `EOFException`.
2. Sending empty strings
   The arguments sent to the server include empty strings which the nailgun server cannot process correctly. The right approach would be to filter out the unused arguments before sending them. My quick solution was to add a 'space' if the argument is empty, simple as that.
