### PR TITLE
Fix -J argument parsing.

### DIFF
--- a/dist/src/dist/bin/zinc
+++ b/dist/src/dist/bin/zinc
@@ -75,7 +75,8 @@ while [[ $# -gt 0 ]] ; do
 
     -J*)
       java_args=("${java_args[@]}" "${1:2}")
-      args=("${args[@]}" "$1")
+      # need zinc not to error out on -J arguments to keep them in args
+      # args=("${args[@]}" "$1")
       shift ;;
 
     *)


### PR DESCRIPTION
zinc fails on -J arguments because it's also keeping them
in args, then deciding they are invalid arguments.  scalac
will accept them if passed along, but zinc is failing of its
own accord.  This was the easy fix; alternatively you can
pass them along, but it's only necessary if you need scala
to be aware of them.
