### PR TITLE
More flexible splitting.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 project/project
 target
+.idea
+*.jar
+*.iml

--- a/src/main/scala/com/typesafe/zinc/Main.scala
+++ b/src/main/scala/com/typesafe/zinc/Main.scala
@@ -5,7 +5,6 @@
 package com.typesafe.zinc
 
 import java.io.File
-import sbt.inc.Analysis
 import sbt.Level
 import xsbti.CompileFailed
 

--- a/src/main/scala/com/typesafe/zinc/Settings.scala
+++ b/src/main/scala/com/typesafe/zinc/Settings.scala
@@ -68,7 +68,7 @@ case class AnalysisUtil(
   cache: Option[File]          = None,
   merge: Seq[File]             = Seq.empty,
   rebase: Option[(File, File)] = None,
-  split: Map[File, File]       = Map.empty,
+  split: Map[Seq[File], File]  = Map.empty,
   reload: Seq[File]            = Seq.empty
 )
 
@@ -131,7 +131,7 @@ object Settings {
     file(    "-cache", "file",               "Analysis cache file to alter",               (s: Settings, f: File) => s.copy(analysisUtil = s.analysisUtil.copy(cache = Some(f)))),
     path(    "-merge", "path",               "Merge analyses, overwrite cached analysis",  (s: Settings, ap: Seq[File]) => s.copy(analysisUtil = s.analysisUtil.copy(merge = ap))),
     filePair("-rebase", "from:to",           "Rebase all analysis product paths",          (s: Settings, p: (File, File)) => s.copy(analysisUtil = s.analysisUtil.copy(rebase = Some(p)))),
-    fileMap( "-split",                       "Split analysis by source directory",         (s: Settings, m: Map[File, File]) => s.copy(analysisUtil = s.analysisUtil.copy(split = m))),
+    fileSeqMap( "-split",                    "Split analysis by source directory",         (s: Settings, m: Map[Seq[File], File]) => s.copy(analysisUtil = s.analysisUtil.copy(split = m))),
     file(    "-reload", "cache-file",        "Reload analysis from cache file",            (s: Settings, f: File) => s.copy(analysisUtil = s.analysisUtil.copy(reload = s.analysisUtil.reload :+ f)))
   )
 
@@ -208,7 +208,7 @@ object Settings {
           cache = Util.normaliseOpt(cwd)(analysisUtil.cache),
           merge = Util.normaliseSeq(cwd)(analysisUtil.merge),
           rebase = analysisUtil.rebase map Util.normalisePair(cwd),
-          split = Util.normaliseMap(cwd)(analysisUtil.split),
+          split = Util.normaliseSeqMap(cwd)(analysisUtil.split),
           reload = Util.normaliseSeq(cwd)(analysisUtil.reload)
         )
       )
@@ -227,6 +227,7 @@ object Settings {
   def prefix(pre: String, arg: String, desc: String, action: (Settings, String) => Settings) = new PrefixOption[Settings](pre, arg, desc, action)
   def filePair(opt: String, arg: String, desc: String, action: (Settings, (File, File)) => Settings) = new FilePairOption[Settings](Seq(opt), arg, desc, action)
   def fileMap(opt: String, desc: String, action: (Settings, Map[File, File]) => Settings) = new FileMapOption[Settings](Seq(opt), desc, action)
+  def fileSeqMap(opt: String, desc: String, action: (Settings, Map[Seq[File], File]) => Settings) = new FileSeqMapOption[Settings](Seq(opt), desc, action)
   def header(label: String) = new HeaderOption[Settings](label)
   def dummy(opt: String, desc: String) = new DummyOption[Settings](opt, desc)
 }

--- a/src/main/scala/com/typesafe/zinc/Util.scala
+++ b/src/main/scala/com/typesafe/zinc/Util.scala
@@ -102,6 +102,13 @@ object Util {
   }
 
   /**
+   * Normalise file sequence map in relation to actual current working directory.
+   */
+  def normaliseSeqMap(cwd: Option[File])(mapped: Map[Seq[File], File]): Map[Seq[File], File] = {
+    if (cwd.isDefined) mapped map { case (l, r) => (normaliseSeq(cwd)(l), normalise(cwd)(r)) } else mapped
+  }
+
+  /**
    * Fully relativize a path, relative to any other base.
    */
   def relativize(base: File, path: File): String = {


### PR DESCRIPTION
Support for splitting zinc analysis files on a source-by-source
basis instead of by source root dir.

Syntax is:

-split {sourceA1:sourceA2:...}:analysisA,{sourceB1:sourceB2...}:analysisB,...
