### PR TITLE
Fix zinc rebase implementation.

### DIFF
--- a/src/main/scala/com/typesafe/zinc/SbtAnalysis.scala
+++ b/src/main/scala/com/typesafe/zinc/SbtAnalysis.scala
@@ -5,7 +5,7 @@
 package com.typesafe.zinc
 
 import java.io.File
-import sbt.{ CompileSetup, IO, Logger, Path, Relation }
+import sbt.{ CompileSetup, IO, Logger, Relation }
 import sbt.inc.{ APIs, Analysis, Relations, SourceInfos, Stamps }
 import scala.annotation.tailrec
 
@@ -78,23 +78,34 @@ object SbtAnalysis {
 
 
   /**
-   * Create a mapper function that performs multiple rebases. For a given file, it uses the first
-   * rebase it finds that matches, if any. The order of rebases is underfined, so it's highly
-   * recommended that there never be two rebases A1->B1, A2->B2 such that A1 is a prefix of A2.
+   * Create a mapper function that performs multiple rebases. For a given file, it uses the first rebase
+   * it finds in which the source base is a prefix of the file path. If no matching rebase is found, it
+   * returns the original path unchanged.
+   *
+   * The order of rebases is undefined, so it's highly recommended that there never be two
+   * rebases A1->B1, A2->B2 such that A1 is a prefix of A2.
+   *
+   * Note that this doesn't need to do general-purpose relative rebasing for paths with ../ etc. So it
+   * uses a naive prefix-matching algorithm.
    */
+
   def createMultiRebasingMapper(rebase: Map[File, File]): File => Option[File] = {
-    val mappers = rebase map { x: (File, File) => Path.rebase(x._1, x._2) } toList
+    def singleRebase(fromBase: String, toBase: String)(path: String): Option[String] =
+      if (path.startsWith(fromBase)) Some(toBase + path.substring(fromBase.length)) else None
+
+    val rebasers: List[String => Option[String]] =
+      rebase map { x: (File, File) => singleRebase(x._1.getCanonicalPath, x._2.getCanonicalPath) _ } toList
 
     @tailrec
-    def tryRebase(f: File, mappers: List[File => Option[File]]): Option[File] = mappers match {
-      case Nil => None
-      case mapper :: tail => mapper(f) match {
-        case None => tryRebase(f, tail)
+    def tryRebase(path: String, rebasers: List[String => Option[String]]): Option[String] = rebasers match {
+      case Nil => Some(path)
+      case rebaser :: tail => rebaser(path) match {
+        case None => tryRebase(path, tail)
         case fileOpt => fileOpt
       }
     }
 
-    tryRebase(_, mappers)
+    f: File => tryRebase(f.getCanonicalPath, rebasers) map { new File(_) }
   }
 
   /**


### PR DESCRIPTION
The old implementation returned None if the source file didn't
actually exist on the filesystem, and also if there was no matching
rebaser for the source file.

Since we only want to rebase files underneath the given bases, and
we don't need to support relativizing paths with ../ etc., we use an
efficient and naive prefix-matching algorithm, instead of analyzing
path segments.

Requesting a pull into the 0.2 branch. Do I need to do anything special to get this change in master, for future versions? Or is 0.2 periodically merged into master? Thanks!!
