### PR TITLE
Add flag to mirror the analysis cache as text.

### DIFF
--- a/project/Scriptit.scala
+++ b/project/Scriptit.scala
@@ -272,7 +272,6 @@ object Script {
       Command("mkdir", mkdir),
       Command("copy", copy),
       Command("exists", exists),
-      Command("notexists", notexists),
       Command("delete", delete),
       Command("show", show),
       Command("sleep", sleep)
@@ -365,15 +364,6 @@ object Script {
       val absent = paths filter (path => !pathToFile(baseDir, path).exists)
       if (absent.isEmpty) Success("Files exist: " + listed(paths))
       else Failure("Files do not exist: " + listed(absent))
-    }
-
-    /** A command which verifies that a file does not exist, to ensure that
-      * optional outputs are only generated when they should.
-      */
-    def notexists(baseDir: File, paths: Seq[String]): Result = {
-      val present = paths filter (path => pathToFile(baseDir, path).exists)
-      if (present.isEmpty) Success("Files don't exists: " + listed(paths))
-      else Failure("Files should not exist: " + listed(present))
     }
 
     def delete(baseDir: File, paths: Seq[String]): Result = {

--- a/src/main/scala/com/typesafe/zinc/Compiler.scala
+++ b/src/main/scala/com/typesafe/zinc/Compiler.scala
@@ -156,6 +156,9 @@ class Compiler(scalac: AnalyzingCompiler, javac: JavaCompiler) {
     val compileSetup  = new CompileSetup(classesDirectory, new CompileOptions(scalacOptions, javacOptions), scalac.scalaInstance.actualVersion, compileOrder)
     val analysisStore = Compiler.analysisStore(cacheFile)
     val analysis      = aggressive.compile1(sources, cp, compileSetup, analysisStore, getAnalysis, definesClass, scalac, javac, maxErrors, skip, globalsCache)(log)
+    if (mirrorAnalysis) {
+      SbtAnalysis.printRelations(analysis, Some(new File(cacheFile.getPath() + ".relations")), cwd)
+    }
     SbtAnalysis.printOutputs(analysis, outputRelations, outputProducts, cwd, classesDirectory)
     analysis
   }

--- a/src/main/scala/com/typesafe/zinc/Inputs.scala
+++ b/src/main/scala/com/typesafe/zinc/Inputs.scala
@@ -28,7 +28,8 @@ case class Inputs(
   javaOnly: Boolean,
   compileOrder: CompileOrder,
   outputRelations: Option[File],
-  outputProducts: Option[File])
+  outputProducts: Option[File],
+  mirrorAnalysis: Boolean)
 
 object Inputs {
   /**
@@ -48,7 +49,8 @@ object Inputs {
       javaOnly,
       compileOrder,
       analysis.outputRelations,
-      analysis.outputProducts)
+      analysis.outputProducts,
+      analysis.mirrorAnalysis)
   }
 
   /**
@@ -66,7 +68,8 @@ object Inputs {
     javaOnly: Boolean,
     compileOrder: CompileOrder,
     outputRelations: Option[File],
-    outputProducts: Option[File]): Inputs =
+    outputProducts: Option[File],
+    mirrorAnalysis: Boolean): Inputs =
   {
     val normalise: File => File = { _.getCanonicalFile }
     val cp               = classpath map normalise
@@ -77,7 +80,7 @@ object Inputs {
     val analysisMap      = (cp map { file => (file, analysisFor(file, classes, upstreamAnalysis)) }).toMap
     val printRelations   = outputRelations map normalise
     val printProducts    = outputProducts map normalise
-    new Inputs(cp, srcs, classes, scalacOptions, javacOptions, cacheFile, analysisMap, forceClean, Locate.definesClass, javaOnly, compileOrder, printRelations, printProducts)
+    new Inputs(cp, srcs, classes, scalacOptions, javacOptions, cacheFile, analysisMap, forceClean, Locate.definesClass, javaOnly, compileOrder, printRelations, printProducts, mirrorAnalysis)
   }
 
   /**
@@ -91,7 +94,8 @@ object Inputs {
     javacOptions: JList[String],
     analysisCache: File,
     analysisMap: JMap[File, File],
-    compileOrder: String): Inputs =
+    compileOrder: String,
+    mirrorAnalysisCache: Boolean): Inputs =
   inputs(
     classpath.asScala,
     sources.asScala,
@@ -104,7 +108,8 @@ object Inputs {
     javaOnly = false,
     Settings.compileOrder(compileOrder),
     outputRelations = None,
-    outputProducts = None
+    outputProducts = None,
+    mirrorAnalysis = mirrorAnalysisCache
   )
 
   /**

--- a/src/main/scala/com/typesafe/zinc/Main.scala
+++ b/src/main/scala/com/typesafe/zinc/Main.scala
@@ -45,7 +45,7 @@ object Main {
     // analysis manipulation utilities
     if (settings.analysisUtil.run) {
       val exitCode = try {
-        SbtAnalysis.runUtil(settings.analysisUtil, log, settings.analysis.mirrorCacheAsText, cwd)
+        SbtAnalysis.runUtil(settings.analysisUtil, log, settings.analysis.mirrorAnalysis, cwd)
       } catch {
         case e: Exception => log.error(e.getMessage)
         sys.exit(1)

--- a/src/main/scala/com/typesafe/zinc/SbtAnalysis.scala
+++ b/src/main/scala/com/typesafe/zinc/SbtAnalysis.scala
@@ -15,11 +15,11 @@ object SbtAnalysis {
    * Run analysis manipulation utilities.
    */
   def runUtil(util: AnalysisUtil, log: Logger,
-              mirrorCacheAsText: Boolean = false,
+              mirrorAnalysis: Boolean = false,
               cwd: Option[File] = None): Unit = {
-    runMerge(util.cache, util.merge, mirrorCacheAsText, cwd)
-    runRebase(util.cache, util.rebase, mirrorCacheAsText, cwd)
-    runSplit(util.cache, util.split, mirrorCacheAsText, cwd)
+    runMerge(util.cache, util.merge, mirrorAnalysis, cwd)
+    runRebase(util.cache, util.rebase, mirrorAnalysis, cwd)
+    runSplit(util.cache, util.split, mirrorAnalysis, cwd)
     runReload(util.reload)
   }
 
@@ -28,7 +28,7 @@ object SbtAnalysis {
    * The merged analysis will overwrite whatever is in the combined analysis cache.
    */
   def runMerge(combinedCache: Option[File], cacheFiles: Seq[File], 
-               mirrorCacheAsText: Boolean = false,
+               mirrorAnalysis: Boolean = false,
                cwd: Option[File] = None): Unit = {
     if (cacheFiles.nonEmpty) {
       combinedCache match {
@@ -38,7 +38,7 @@ object SbtAnalysis {
           mergeAnalyses(cacheFiles) match {
             case Some((mergedAnalysis, mergedSetup)) => {
                 analysisStore.set(mergedAnalysis, mergedSetup)
-                if (mirrorCacheAsText) {
+                if (mirrorAnalysis) {
                   printRelations(mergedAnalysis, Some(new File(cacheFile.getPath() + ".relations")), cwd)
                 }
               }
@@ -67,7 +67,7 @@ object SbtAnalysis {
    * in the compile setup.
    */
   def runRebase(cache: Option[File], rebase: Map[File, File],
-                mirrorCacheAsText: Boolean, cwd: Option[File]): Unit = {
+                mirrorAnalysis: Boolean, cwd: Option[File]): Unit = {
     if (!rebase.isEmpty) {
       cache match {
         case None => throw new Exception("No cache file specified")
@@ -80,7 +80,7 @@ object SbtAnalysis {
               val newAnalysis = rebaseAnalysis(analysis, multiRebasingMapper)
               val newSetup = rebaseSetup(compileSetup, multiRebasingMapper)
               analysisStore.set(newAnalysis, newSetup)
-              if (mirrorCacheAsText) {
+              if (mirrorAnalysis) {
                 printRelations(analysis, Some(new File(cacheFile.getPath() + ".relations")), cwd)
               }
             }
@@ -168,7 +168,7 @@ object SbtAnalysis {
    * the mapped analysis cache files.
    */
   def runSplit(cache: Option[File], mapping: Map[Seq[File], File],
-              mirrorCacheAsText: Boolean = false,
+              mirrorAnalysis: Boolean = false,
               cwd: Option[File] = None): Unit = {
     if (mapping.nonEmpty) {
       cache match {
@@ -181,8 +181,8 @@ object SbtAnalysis {
                 val outsideSources = findOutsideSources(analysis, sources)
                 val splitAnalysis = analysis -- outsideSources
                 Compiler.analysisStore(splitCache).set(splitAnalysis, compileSetup)
-                if (mirrorCacheAsText) {
-                  printRelations(splitAnalysis, Some(splitCache.getPath() + ".relations"), cwd)
+                if (mirrorAnalysis) {
+                  printRelations(splitAnalysis, Some(new File(splitCache.getPath() + ".relations")), cwd)
                 }
               }
           }

--- a/src/main/scala/com/typesafe/zinc/Settings.scala
+++ b/src/main/scala/com/typesafe/zinc/Settings.scala
@@ -105,7 +105,7 @@ case class AnalysisOptions(
   forceClean: Boolean           = false,
   outputRelations: Option[File] = None,
   outputProducts: Option[File]  = None,
-  mirrorCacheAsText: Boolean = false
+  mirrorAnalysis: Boolean = false
 )
 
 /**
@@ -159,8 +159,8 @@ object Settings {
     file(    "-analysis-cache", "file",      "Cache file for compile analysis",            (s: Settings, f: File) => s.copy(analysis = s.analysis.copy(cache = Some(f)))),
     fileMap( "-analysis-map",                "Upstream analysis mapping (file:file,...)",  (s: Settings, m: Map[File, File]) => s.copy(analysis = s.analysis.copy(cacheMap = m))),
     boolean( "-force-clean",                 "Force clean classes on empty analysis",      (s: Settings) => s.copy(analysis = s.analysis.copy(forceClean = true))),
-    boolean("-mirror-cache-as-text",  "Store a side-mirror of the analysis cache as readable text",
-            (s: Settings) => s.copy(analysis = s.analysis.copy(mirrorCacheAsText = true))),
+    boolean("-mirror-analysis",  "Store a side-mirror of the analysis cache as readable text",
+            (s: Settings) => s.copy(analysis = s.analysis.copy(mirrorAnalysis = true))),
     file(    "-output-relations", "file",    "Print readable analysis relations to file",  (s: Settings, f: File) => s.copy(analysis = s.analysis.copy(outputRelations = Some(f)))),
     file(    "-output-products", "file",     "Print readable source products to file",     (s: Settings, f: File) => s.copy(analysis = s.analysis.copy(outputProducts = Some(f)))),
 

--- a/src/scriptit/analysis/cache/test
+++ b/src/scriptit/analysis/cache/test
@@ -3,9 +3,12 @@
 zinc -nailed -debug -d a/target/classes -analysis-cache a/target/analysis/compile a/src/A.scala
 
 exists a/target/classes/A.class a/target/analysis/compile
-
 zinc -nailed -debug -cp a/target/classes -d b/target/classes -analysis-cache b/target/analysis/compile -analysis-map a/target/classes:a/target/analysis/compile b/src/B.scala
 
 exists b/target/classes/B.class b/target/analysis/compile
+
+! exists b/target/analysis/compile.relations
+zinc -nailed -debug -cp a/target/classes -d b/target/classes -mirror-analysis -analysis-cache b/target/analysis/compile -analysis-map a/target/classes:a/target/analysis/compile b/src/B.scala
+exists b/target/analysis/compile.relations
 
 zinc -shutdown

--- a/src/scriptit/analysis/merge/test
+++ b/src/scriptit/analysis/merge/test
@@ -11,8 +11,8 @@ zinc -nailed -analysis -cache analysis/abc -merge analysis/a:analysis/b:analysis
 zinc -nailed -analysis-cache analysis/abc -d classes -output-relations relations/abc a/A.scala b/B.scala c/C.scala
 
 # rerun, this time with text mirroring
-notexists analysis/abc.relations
-zinc -nailed -analysis -cache analysis/abc -mirror-cache-as-text -merge analysis/a:analysis/b:analysis/c
+! exists analysis/abc.relations
+zinc -nailed -analysis -cache analysis/abc -mirror-analysis -merge analysis/a:analysis/b:analysis/c
 exists analysis/abc.relations
 
 

--- a/src/scriptit/analysis/rebase/test
+++ b/src/scriptit/analysis/rebase/test
@@ -18,8 +18,8 @@ show r1
 
 show r2
 
-notexists a2.relations
-zinc -nailed -mirror-cache-as-text -analysis -cache a2 -rebase c1:c2
+! exists a2.relations
+zinc -nailed -mirror-analysis -analysis -cache a2 -rebase c1:c2
 exists a2.relations
 
 

--- a/src/scriptit/analysis/split/test
+++ b/src/scriptit/analysis/split/test
@@ -17,10 +17,10 @@ delete analysis classes relations
 
 zinc -nailed -analysis-cache analysis/abc -d classes -output-relations relations/abc a/a1.scala a/a2.scala b/b1.scala b/b2.scala c/c1.scala c/c2.scala
 
-notexists analysis/a.relations
-notexists analysis/b.relations
-notexists analysis/c.relations
-zinc -nailed -analysis -mirror-cache-as-text -cache analysis/abc -split {a/a1.scala:a/a2.scala}:analysis/a,{b/b1.scala:b/b2.scala}:analysis/b,{c/c1.scala:c/c2.scala}:analysis/c
+! exists analysis/a.relations
+! exists analysis/b.relations
+! exists analysis/c.relations
+zinc -nailed -analysis -mirror-analysis -cache analysis/abc -split {a/a1.scala:a/a2.scala}:analysis/a,{b/b1.scala:b/b2.scala}:analysis/b,{c/c1.scala:c/c2.scala}:analysis/c
 
 # Verify that the merge generated the text mirror files.
 exists analysis/a.relations


### PR DESCRIPTION
When working with zinc in a non-java based builder, it is useful to be able to
look at the same analysis cache being used by the compiler.  The current
"printRelations" flag requests that a compilation emits a textual
version of the cache. For compilation, this is adequate.  However, after
compilation, we frequently need to manipulate the analysis cache, doing merges
and splits to have analysis caches that match the build system's compilation
groupings.

In order to enable us to have a textual cache in sync with the
merged/split/rebased cache, in this change, I've added an option to the analysis
manipulation commands, "-mirror-cache-as-text".  When this flag is specified, a
readable text ".relations" file is generated, side-by-side with the original cache.

In order to test this, the change also adds a command to scriptit to check that
a particular file does not exists.  This allowed me to write tests that
verified that the text mirror files were only generated when the option was
passed.
