### PR TITLE
New implementation of rebasing.

### DIFF
--- a/src/main/scala/com/typesafe/zinc/Compiler.scala
+++ b/src/main/scala/com/typesafe/zinc/Compiler.scala
@@ -66,7 +66,8 @@ object Compiler {
    * Get or create an analysis store.
    */
   def analysisStore(cacheFile: File): AnalysisStore = {
-    analysisCache.get(cacheFile)(createAnalysisStore(cacheFile))
+    analysisCache.get(cacheFile)(
+      createAnalysisStore(cacheFile))
   }
 
   /**
@@ -82,7 +83,7 @@ object Compiler {
    * Get an analysis, lookup by cache file.
    */
   def analysis(cacheFile: File): Analysis = {
-    analysisStore(cacheFile).get map (_._1) getOrElse Analysis.Empty
+    analysisStore(cacheFile).get().map (_._1).getOrElse(Analysis.Empty)
   }
 
   /**

--- a/src/main/scala/com/typesafe/zinc/Options.scala
+++ b/src/main/scala/com/typesafe/zinc/Options.scala
@@ -169,7 +169,11 @@ extends ArgumentOption[Map[File, File], Context] {
 
   def parseFilePair(pair: String): Option[(File, File)] = {
     val p = pair split pairSeparator
-    if (p.length == 2) Some((new File(p(0)), new File(p(1)))) else None
+    p.length match {
+      case 1 => Some((new File(p(0)), new File("")))
+      case 2 => Some((new File(p(0)), new File(p(1))))
+      case _ => None
+    }
   }
 }
 


### PR DESCRIPTION
Supports rebasing a file to nothing: If the new base is blank,
the path is deleted from the analysis cache file. This is useful
for getting rid of JVM dependency info, which isn't portable and
can be unnecessary in practice, since people switch JVMs infrequently.

Uses partial functions, so we can distinguish between "I don't
match this path" and "I do match this path, and want to rebase it
to nothingness". This is a more elegant approach, since rebasings
are in fact just partial functions on the domain of paths.
