### PR TITLE
Bugfix with mirroring the analysis after rebasing.

### DIFF
--- a/src/main/scala/com/typesafe/zinc/SbtAnalysis.scala
+++ b/src/main/scala/com/typesafe/zinc/SbtAnalysis.scala
@@ -81,7 +81,7 @@ object SbtAnalysis {
               val newSetup = rebaseSetup(compileSetup, multiRebasingMapper)
               analysisStore.set(newAnalysis, newSetup)
               if (mirrorAnalysis) {
-                printRelations(analysis, Some(new File(cacheFile.getPath() + ".relations")), cwd)
+                printRelations(newAnalysis, Some(new File(cacheFile.getPath() + ".relations")), cwd)
               }
             }
           }


### PR DESCRIPTION
It must reflect the new analysis state, not the old one.
