### PR TITLE
Allow the output dir to be a provider of upstream analysis.

### DIFF
--- a/src/main/scala/com/typesafe/zinc/Inputs.scala
+++ b/src/main/scala/com/typesafe/zinc/Inputs.scala
@@ -133,8 +133,8 @@ object Inputs {
    * for the cache location, otherwise uses the default location for output directories.
    */
   def cacheFor(file: File, exclude: File, mapped: Map[File, File]): Option[File] = {
-    if (file == exclude) None else mapped.get(file) orElse {
-      if (file.isDirectory) Some(defaultCacheLocation(file)) else None
+    mapped.get(file) orElse {
+      if (file.isDirectory && file != exclude) Some(defaultCacheLocation(file)) else None
     }
   }
 


### PR DESCRIPTION
Previously it was always excluded. Now it's only excluded if it
doesn't have an explicit entry in the upstream analysis map.

This is necessary for chunked builds that output to the same
output directory.
