### PR TITLE
Format implicits are no longer needed.

### DIFF
--- a/src/main/scala/com/typesafe/zinc/Compiler.scala
+++ b/src/main/scala/com/typesafe/zinc/Compiler.scala
@@ -85,9 +85,6 @@ object Compiler {
    * Create an analysis store backed by analysisCache.
    */
   def analysisStore(cacheFile: File): AnalysisStore = {
-    import sbinary.DefaultProtocol.{immutableMapFormat, immutableSetFormat, StringFormat, tuple2Format}
-    import sbt.inc.AnalysisFormats._
-
     val fileStore = AnalysisStore.cached(FileBasedStore(cacheFile))
 
     val fprintStore = new AnalysisStore {


### PR DESCRIPTION
As of SBT 0.13.1-RC3 the analysis file is a text file.

Can we get a release of Zinc with this change, against that version of SBT? Right now we're using a version I built and deployed internally, but it would be better if there was an official version we could rely on. Thanks!
