### PR TITLE
Migrate to non-deprecated constructor of CompileSetup.

### DIFF
--- a/src/main/scala/com/typesafe/zinc/Compiler.scala
+++ b/src/main/scala/com/typesafe/zinc/Compiler.scala
@@ -178,9 +178,9 @@ class Compiler(scalac: AnalyzingCompiler, javac: JavaCompiler) {
     val maxErrors     = 100
     val reporter      = new LoggerReporter(maxErrors, log, identity)
     val skip          = false
-    val compileSetup  = new CompileSetup(compileOutput, new CompileOptions(scalacOptions, javacOptions), scalac.scalaInstance.actualVersion, compileOrder)
-    val analysisStore = Compiler.analysisStore(cacheFile)
     val incOpts       = incOptions.options
+    val compileSetup  = new CompileSetup(compileOutput, new CompileOptions(scalacOptions, javacOptions), scalac.scalaInstance.actualVersion, compileOrder, incOpts.nameHashing)
+    val analysisStore = Compiler.analysisStore(cacheFile)
     val analysis      = aggressive.compile1(sources, cp, compileSetup, progress, analysisStore, getAnalysis, definesClass, scalac, javac, reporter, skip, globalsCache, incOpts)(log)
     if (mirrorAnalysis) {
       SbtAnalysis.printRelations(analysis, Some(new File(cacheFile.getPath() + ".relations")), cwd)

--- a/src/main/scala/com/typesafe/zinc/SbtAnalysis.scala
+++ b/src/main/scala/com/typesafe/zinc/SbtAnalysis.scala
@@ -168,7 +168,7 @@ object SbtAnalysis {
    */
   def rebaseSetup(setup: CompileSetup, mapper: File => Option[File]): CompileSetup = {
     val output = Some(setup.output) collect { case single: SingleOutput => single.outputDirectory }
-    output flatMap mapper map { dir => new CompileSetup(CompileOutput(dir), setup.options, setup.compilerVersion, setup.order) } getOrElse setup
+    output flatMap mapper map { dir => new CompileSetup(CompileOutput(dir), setup.options, setup.compilerVersion, setup.order, setup.nameHashing) } getOrElse setup
   }
 
   /**


### PR DESCRIPTION
The sbt/sbt#1122 and sbt/sbt#1125 introduced additional argument
(nameHashing flag) to CompileSetup and deprecated the old constructor.
Let's catch up with this change in zinc now.
