### PR TITLE
Use Scala 2.11.0-RC3 in scriptit tests.

### DIFF
--- a/project/Scriptit.scala
+++ b/project/Scriptit.scala
@@ -22,7 +22,7 @@ object Scriptit {
     scriptitTestName := "test",
     scriptitCommands := Commands.defaultCommands,
     scriptitCommands <+= (Dist.create in ZincBuild.dist) map Commands.zincCommand,
-    scriptitScalaVersions := Seq("2.9.3", "2.10.3", "2.11.0-M4"),
+    scriptitScalaVersions := Seq("2.9.3", "2.10.3", "2.11.0-RC3"),
     scriptitProperties <<= (appConfiguration, scriptitScalaVersions) map scalaProperties,
     scriptitProperties ++= javaProperties,
     scriptit <<= scriptitTask

--- a/src/scriptit/scala/2.11/jars/test
+++ b/src/scriptit/scala/2.11/jars/test
@@ -1,5 +1,5 @@
 # use scala 2.11 jars
 
-zinc -debug -scala-library {{scala.2.11.library}} -scala-compiler {{scala.2.11.compiler}} -scala-extra {{scala.2.11.extra}} A.scala
+zinc -debug -scala-library {{scala.2.11.0-RC3.library}} -scala-compiler {{scala.2.11.0-RC3.compiler}} -scala-extra {{scala.2.11.0-RC3.extra}} A.scala
 
 exists A.class


### PR DESCRIPTION
Switch to Scala 2.11.0-RC3 running scriptit tests. Also, update
scala/2.11/jars/test to use full version number for Scala 2.11.0-RC3.
The reason we need to switch to full version is change in sbt's definition
of binaryVersion that scriptit uses. In sbt 0.13 all Scala milestones and
release candidates are considered to be binary incompatible hence
binaryVersion is a full version number.

This has been missed during upgrade to sbt 0.13 of zinc.
