### PR TITLE
Fix binary compatibility of Setup.create methods.

### DIFF
--- a/src/main/scala/com/typesafe/zinc/Setup.scala
+++ b/src/main/scala/com/typesafe/zinc/Setup.scala
@@ -108,6 +108,17 @@ object Setup {
     forkJava
   )
 
+  @deprecated("Use variant that takes forkJava parameter instead.", "0.3.6")
+  def create(
+    scalaCompiler: File,
+    scalaLibrary: File,
+    scalaExtra: JList[File],
+    sbtInterface: File,
+    compilerInterfaceSrc: File,
+    javaHome: File): Setup =
+      create(scalaCompiler, scalaLibrary, scalaExtra, sbtInterface,
+        compilerInterfaceSrc, javaHome, false)
+
   /**
    * Java API for creating Setup with ScalaLocation and SbtJars.
    */
@@ -129,6 +140,12 @@ object Setup {
       forkJava
     )
   }
+
+  @deprecated("Use variant that takes forkJava parameter instead.", "0.3.6")
+  def create(
+    scalaLocation: ScalaLocation,
+    sbtJars: SbtJars,
+    javaHome: File): Setup = create(scalaLocation, sbtJars, javaHome, false)
 
   /**
    * Select the scala jars.


### PR DESCRIPTION
In minor releases we guarantee binary compatibility but
c7ec3120 slipped through the cracks. This change fixes the breakage
introduced in c7ec3120.

Fixes #44.
