### PR TITLE
Restore binary compatibility of IncOptions constructor.

### DIFF
--- a/src/main/scala/com/typesafe/zinc/Settings.scala
+++ b/src/main/scala/com/typesafe/zinc/Settings.scala
@@ -118,6 +118,21 @@ case class IncOptions(
   recompileOnMacroDef: Boolean   = DefaultIncOptions.recompileOnMacroDef,
   nameHashing: Boolean           = DefaultIncOptions.nameHashing
 ) {
+  @deprecated("Use the primary constructor instead.", "0.3.5.2")
+  def this(
+    transitiveStep: Int,
+    recompileAllFraction: Double,
+    relationsDebug: Boolean,
+    apiDebug: Boolean,
+    apiDiffContextSize: Int,
+    apiDumpDirectory: Option[File],
+    transactional: Boolean,
+    backup: Option[File]
+  ) = {
+    this(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize,
+      apiDumpDirectory, transactional, backup, DefaultIncOptions.recompileOnMacroDef,
+      DefaultIncOptions.nameHashing)
+  }
   def options: sbt.inc.IncOptions = {
     sbt.inc.IncOptions(
       transitiveStep,


### PR DESCRIPTION
The 6f7467363a5de9272ecc2f3dd4cd371d6378627f introduced support for new
fields in IncOptions class but broke binary compatibility. Let's add
overloaded (and deprecated) constructor which fixes binary compatibility
of constructor.

NOTE: The IncOptions in zinc is a case class so restoring full binary
compatibility (for example, of copy method) is not feasible.
