### PR TITLE
Restore binary backwards compatibility of Inputs.create method.

### DIFF
--- a/src/main/scala/com/typesafe/zinc/Inputs.scala
+++ b/src/main/scala/com/typesafe/zinc/Inputs.scala
@@ -121,6 +121,20 @@ object Inputs {
     mirrorAnalysis = mirrorAnalysisCache
   )
 
+  @deprecated("Use the variant that takes `incOptions` parameter, instead.", "0.3.5.3")
+  def create(
+    classpath: JList[File],
+    sources: JList[File],
+    classesDirectory: File,
+    scalacOptions: JList[String],
+    javacOptions: JList[String],
+    analysisCache: File,
+    analysisMap: JMap[File, File],
+    compileOrder: String,
+    mirrorAnalysisCache: Boolean): Inputs =
+    create(classpath, sources, classesDirectory, scalacOptions, javacOptions,
+      analysisCache, analysisMap, compileOrder, IncOptions(), mirrorAnalysisCache)
+
   /**
    * By default the cache location is relative to the classes directory (for example, target/classes/../cache/classes).
    */


### PR DESCRIPTION
The `Inputs.create` method has been modified by
60c7e4d375ee280a5876650d26cae9edd8668879 to add support for IncOptions.
That broke both binary and source compatibility. Let's restore the old
signature for Inputs.create and deprecate it at the same time.

Fixes another instance of #44.
