### PR TITLE
Fix publish after #62, close #71

### DIFF
--- a/project/Dist.scala
+++ b/project/Dist.scala
@@ -29,11 +29,10 @@ object Dist {
     },
     artifact in packageZipTarball in Universal :=  Artifact("zinc", "tgz", "tgz"),
     publishMavenStyle := true,
-    publishArtifact in makePom := false,
-    publishArtifact := false,
+    publishArtifact in Universal := false,
     publishTo := Some("zinc repo" at "http://typesafe.artifactoryonline.com/typesafe/zinc"),
     credentials += Credentials(Path.userHome / ".ivy2" / "artifactory-credentials")
-  ) ++ addArtifact(artifact in packageZipTarball in Universal, packageZipTarball in Universal)
+  )
 
   lazy val s3PublishSettings: Seq[Setting[_]] = s3Settings ++ Seq(
     mappings in S3.upload := {


### PR DESCRIPTION
This fixes a regression introduced by me in #62.
Since the `dist` project was merged into the main project, disabling artifact publication in `Dist.settings` effectively disabled publication of JARs and POM file, leaving only the bundle, which should not be published to Sonatype.

Really sorry for the incovenience.