### PR TITLE
jmouradi/add progress reporting interface implementation

### DIFF
--- a/src/main/scala/com/typesafe/zinc/Compiler.scala
+++ b/src/main/scala/com/typesafe/zinc/Compiler.scala
@@ -175,14 +175,12 @@ class Compiler(scalac: AnalyzingCompiler, javac: JavaCompiler) {
   }
 
   /**
-   * This is run deterministically, no matter what the inputs are.
    * Run a compile. The resulting analysis is also cached in memory.
-   *
-   * Modified version of the original variant to output the beginning of each compilation phase for each unit.
-   *
+   * 
+   *  Note: This variant does not report progress updates
    */
   def compile(inputs: Inputs, cwd: Option[File], reporter: xsbti.Reporter)(log: Logger): Analysis = {
-    compile(inputs, cwd, reporter, progress = Some(new SimpleCompileProgress()))(log)
+    compile(inputs, cwd, reporter, progress = None)(log)
   }
 
   /**

--- a/src/main/scala/com/typesafe/zinc/Compiler.scala
+++ b/src/main/scala/com/typesafe/zinc/Compiler.scala
@@ -175,12 +175,14 @@ class Compiler(scalac: AnalyzingCompiler, javac: JavaCompiler) {
   }
 
   /**
+   * This is run deterministically, no matter what the inputs are.
    * Run a compile. The resulting analysis is also cached in memory.
-   * 
-   *  Note: This variant does not report progress updates
+   *
+   * Modified version of the original variant to output the beginning of each compilation phase for each unit.
+   *
    */
   def compile(inputs: Inputs, cwd: Option[File], reporter: xsbti.Reporter)(log: Logger): Analysis = {
-    compile(inputs, cwd, reporter, progress = None)(log)
+    compile(inputs, cwd, reporter, progress = Some(new SimpleCompileProgress()))(log)
   }
 
   /**

--- a/src/main/scala/com/typesafe/zinc/SimpleCompileProgress.scala
+++ b/src/main/scala/com/typesafe/zinc/SimpleCompileProgress.scala
@@ -1,0 +1,23 @@
+package com.typesafe.zinc
+
+import xsbti.compile.{ CompileProgress }
+import math.max
+
+/**
+ * Created by jmouradian on 4/14/15.
+ */
+class SimpleCompileProgress extends CompileProgress {
+  var lastCurrent: Int = 0  // The last number of steps to have been completed.
+
+  def startUnit(phase: String, unitPath: String) : Unit = {
+    // Notify the user of the current compilation phase.
+    println(phase + " " + unitPath + "...")
+  }
+
+  // Always advance. If there exists progress to report to the user, print to stdout.
+  def advance(current: Int, total: Int): Boolean = {
+    if (current > lastCurrent) println("Progress: [" + current + "/" + total + "]")
+    lastCurrent = math.max(current, lastCurrent)
+    true
+  }
+}

--- a/src/main/scala/com/typesafe/zinc/SimpleCompileProgress.scala
+++ b/src/main/scala/com/typesafe/zinc/SimpleCompileProgress.scala
@@ -6,27 +6,32 @@ import xsbti.compile.CompileProgress
  * SimpleCompileProgress implements CompileProgress to add output to zinc scala compilations, but
  * does not implement the capability to cancel compilations via the `advance` method.
  */
-class SimpleCompileProgress extends CompileProgress {
-  /**
-   * lastCurrent tracks the latest reported number of currently completed compilation units.
-   */
+class SimpleCompileProgress (printUnits: Boolean, printProgress: Boolean) extends CompileProgress {
   var lastCurrent: Int = 0  
 
   /** 
-   * startUnit is called when SBT begins a compilation phase of a given file, and reports to stdout.
+   * startUnit Optionally reports to stdout when a phase of compilation has begun for a file.
    */
-  def startUnit(phase: String, unitPath: String): Unit =  println(phase + " " + unitPath + "...")
+  def startUnit(phase: String, unitPath: String): Unit =  {
+    if (printUnits) {
+      println(phase + " " + unitPath + "...")
+    }
+  }
 
   /**
+   * advance Optionally reports the number of compilation units completed out of the total.
+   * 
    * advance is periodically called during compilation, indicating the total number of compilation 
    * steps completed (`current`) out of the total number of steps necessary. The method returns 
    * false if the user wishes to cancel compilation, or true otherwise. Currently, Zinc never 
    * requests to cancel compilation.
    */
   def advance(current: Int, total: Int): Boolean = {
-    if (current > lastCurrent) {
-      println("Progress: [" + current + "/" + total + "]")
-      lastCurrent = current 
+    if (printProgress) {
+      if (current > lastCurrent) {
+        println("Progress: [" + current + "/" + total + "]")
+        lastCurrent = current 
+      }
     }
     true
   }

--- a/src/main/scala/com/typesafe/zinc/SimpleCompileProgress.scala
+++ b/src/main/scala/com/typesafe/zinc/SimpleCompileProgress.scala
@@ -1,20 +1,13 @@
 package com.typesafe.zinc
 
-import xsbti.compile.{ CompileProgress }
 import math.max
+import xsbti.compile.CompileProgress
 
-/**
- * Created by jmouradian on 4/14/15.
- */
 class SimpleCompileProgress extends CompileProgress {
-  var lastCurrent: Int = 0  // The last number of steps to have been completed.
+  var lastCurrent: Int = 0  
 
-  def startUnit(phase: String, unitPath: String) : Unit = {
-    // Notify the user of the current compilation phase.
-    println(phase + " " + unitPath + "...")
-  }
+  def startUnit(phase: String, unitPath: String): Unit =  println(phase + " " + unitPath + "...")
 
-  // Always advance. If there exists progress to report to the user, print to stdout.
   def advance(current: Int, total: Int): Boolean = {
     if (current > lastCurrent) println("Progress: [" + current + "/" + total + "]")
     lastCurrent = math.max(current, lastCurrent)

--- a/src/main/scala/com/typesafe/zinc/SimpleCompileProgress.scala
+++ b/src/main/scala/com/typesafe/zinc/SimpleCompileProgress.scala
@@ -2,11 +2,27 @@ package com.typesafe.zinc
 
 import xsbti.compile.CompileProgress
 
+/**
+ * SimpleCompileProgress implements CompileProgress to add output to zinc scala compilations, but
+ * does not implement the capability to cancel compilations via the `advance` method.
+ */
 class SimpleCompileProgress extends CompileProgress {
+  /**
+   * lastCurrent tracks the latest reported number of currently completed compilation units.
+   */
   var lastCurrent: Int = 0  
 
+  /** 
+   * startUnit is called when SBT begins a compilation phase of a given file, and reports to stdout.
+   */
   def startUnit(phase: String, unitPath: String): Unit =  println(phase + " " + unitPath + "...")
 
+  /**
+   * advance is periodically called during compilation, indicating the total number of compilation 
+   * steps completed (`current`) out of the total number of steps necessary. The method returns 
+   * false if the user wishes to cancel compilation, or true otherwise. Currently, Zinc never 
+   * requests to cancel compilation.
+   */
   def advance(current: Int, total: Int): Boolean = {
     if (current > lastCurrent) {
       println("Progress: [" + current + "/" + total + "]")

--- a/src/main/scala/com/typesafe/zinc/SimpleCompileProgress.scala
+++ b/src/main/scala/com/typesafe/zinc/SimpleCompileProgress.scala
@@ -1,6 +1,5 @@
 package com.typesafe.zinc
 
-import math.max
 import xsbti.compile.CompileProgress
 
 class SimpleCompileProgress extends CompileProgress {
@@ -9,8 +8,10 @@ class SimpleCompileProgress extends CompileProgress {
   def startUnit(phase: String, unitPath: String): Unit =  println(phase + " " + unitPath + "...")
 
   def advance(current: Int, total: Int): Boolean = {
-    if (current > lastCurrent) println("Progress: [" + current + "/" + total + "]")
-    lastCurrent = math.max(current, lastCurrent)
+    if (current > lastCurrent) {
+      println("Progress: [" + current + "/" + total + "]")
+      lastCurrent = current 
+    }
     true
   }
 }


### PR DESCRIPTION
Adds SimpleCompileProgress, an implementation of xsbti's CompileProgress, which can be supplied to a call to SBT to receive progress updates. SimpleCompileProgress takes two arguments (to be supplied by the command line in a future revision) which throttle whether to print this output.