### PR TITLE
Add more recent scala/jdk versions and enhance travisCI build process ( PR#97)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ target
 .idea
 *.jar
 *.iml
+*.*~
+.*~

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,38 @@
+cache:
+  directories:
+    - $HOME/.m2/repository
+    - $HOME/.sbt
+    - $HOME/.ivy2
+branches:
+  only:
+    - master
 language: scala
+scala:
+   - 2.9.3
+   - 2.10.4
+   - 2.11.2
 script:
   - sbt scriptit
+  # Trick to avoid unnecessary cache updates
+  - find $HOME/.sbt -name "*.lock" | xargs rm
+  - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
+
 jdk:
+  - oraclejdk8
+  # - openjdk8 TravisCI is still working on this
+  - oraclejdk7
+  - openjdk7
   - openjdk6
+
+matrix:
+  exclude:
+    - scala: 2.9.3
+      jdk: oraclejdk8
+    - scala: 2.10.4
+      jdk: oraclejdk8
+    - scala: 2.11.2
+      jdk: oraclejdk8
+
 notifications:
   email:
   # TODO: change to zinc@typesafe.com once permissions to send emails from

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Zinc
 ====
 
+[![Build Status](https://travis-ci.org/typesafehub/zinc.svg?branch=master)](https://travis-ci.org/typesafehub/zinc)
+
 Zinc is a stand-alone version of [sbt]'s incremental compiler.
 
 Download the [latest stable version][download].


### PR DESCRIPTION
The related PR ( #97)
- add build cache to speedup buid time
- add default branch travisCI to build from
- add build matrix to include supported combinations of scala & jdk versions