### PR TITLE
Add server parameter to control address Nailgun server binds to

### DIFF
--- a/src/main/scala/com/typesafe/zinc/Nailgun.scala
+++ b/src/main/scala/com/typesafe/zinc/Nailgun.scala
@@ -4,8 +4,9 @@
 
 package com.typesafe.zinc
 
-import com.martiansoftware.nailgun.{ Alias, AliasManager, NGContext, NGServer }
+import com.martiansoftware.nailgun.{ Alias, NGContext, NGServer }
 import java.io.File
+import java.net.InetAddress
 import sbt.Path
 
 class Nailgun // for classOf
@@ -21,8 +22,9 @@ object Nailgun {
    */
   def main(args: Array[String]): Unit = {
     val port = try args(0).toInt catch { case _: Exception => DefaultPort }
+    val server = try InetAddress.getByName(args(2)) catch { case _: Exception => null }
     val timeout = try Util.duration(args(1), DefaultTimeout) catch { case _: Exception => DefaultTimeout }
-    start(port, timeout)
+    start(server, port, timeout)
   }
 
   /**
@@ -60,8 +62,8 @@ object Nailgun {
    * Start the nailgun server.
    * Available aliased commands are 'zinc', 'status', and 'shutdown'.
    */
-  def start(port: Int, timeout: Long): Unit = {
-    val server = new NGServer(null, port)
+  def start(address: InetAddress, port: Int, timeout: Long): Unit = {
+    val server = new NGServer(address, port)
     val am = server.getAliasManager
     am.addAlias(new Alias("zinc", "scala incremental compiler", classOf[Nailgun]))
     am.addAlias(new Alias("status", "status of nailgun server", classOf[Nailgun]))

--- a/src/main/scala/com/typesafe/zinc/Settings.scala
+++ b/src/main/scala/com/typesafe/zinc/Settings.scala
@@ -243,6 +243,7 @@ object Settings {
 
     header("Nailgun options:"),
     dummy(     "-nailed",                      "Run as daemon with nailgun server"),
+    dummy(     "-server",                      "Set nailgun server address (if nailed)"),
     dummy(     "-port",                        "Set nailgun port (if nailed)"),
     dummy(     "-start",                       "Ensure nailgun server is running (if nailed)"),
     dummy(     "-status",                      "Report nailgun server status (if nailed)"),

--- a/src/universal/bin/zinc
+++ b/src/universal/bin/zinc
@@ -49,6 +49,7 @@ function fork_command {
 
 # nailgun settings
 declare nailgun_port=3030
+declare nailgun_server="0.0.0.0"
 declare timeout=0
 unset nailed start status shutdown
 
@@ -63,6 +64,7 @@ while [[ $# -gt 0 ]] ; do
 
     -nailed) nailed=1; shift ;;
     -port) nailgun_port="$2"; shift 2 ;;
+    -server) nailgun_server="$2"; shift 2 ;;
     -start) start=1; shift ;;
     -status) status=1; shift ;;
     -shutdown) shutdown=1; shift ;;
@@ -209,7 +211,7 @@ function nailgun {
       "${java_options[@]}" \
       -Dzinc.home="$home_path" \
       -classpath "$classpath" \
-      com.typesafe.zinc.Nailgun $nailgun_port $timeout
+      com.typesafe.zinc.Nailgun $nailgun_port $timeout $nailgun_server
     # give some time for startup
     local attempts=50
     while ! check_port $nailgun_port ; do
@@ -218,7 +220,7 @@ function nailgun {
       sleep 0.1
     done
   fi
-  exec_command "$script_dir/nailgun" --nailgun-port $nailgun_port "$@"
+  exec_command "$script_dir/nailgun" --nailgun-server $nailgun_server --nailgun-port $nailgun_port "$@"
 }
 
 if [ -n "$nailed" ] ; then


### PR DESCRIPTION
Adds command line parameter to specify Nailgun server bind address. Example usage to limit listening to 127.0.0.1:
`zinc -start -server 127.0.0.1`
Default behavior when address parameter is not specified is backwards compatible - server binds to all interfaces.

Related issue #47