### PR TITLE
Take advantage of SBT 0.13.13's compiler interface classloader cache

### DIFF
--- a/src/main/scala/com/typesafe/zinc/ClassLoaderCacheAccess.java
+++ b/src/main/scala/com/typesafe/zinc/ClassLoaderCacheAccess.java
@@ -1,0 +1,20 @@
+package com.typesafe.zinc;
+
+import sbt.classpath.ClassLoaderCache;
+import sbt.compiler.AnalyzingCompiler;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+// Subvert the private[sbt] on sbt.classpath.ClassLoaderCache by using javac.
+final class ClassLoaderCacheAccess {
+    private ClassLoaderCacheAccess() {
+    }
+
+    static AnalyzingCompiler withClassLoaderCache(AnalyzingCompiler compiler, Object cache) {
+        return compiler.withClassLoaderCache((ClassLoaderCache) cache);
+    }
+    static Object newClassLoaderCache() {
+        return new ClassLoaderCache(new URLClassLoader(new URL[]{}));
+    }
+}


### PR DESCRIPTION
As SBT itself does:

  https://github.com/sbt/sbt/pull/2754

