### PR TITLE
Additional Compiler.compile method version

### DIFF
--- a/src/main/scala/com/typesafe/zinc/Compiler.scala
+++ b/src/main/scala/com/typesafe/zinc/Compiler.scala
@@ -182,6 +182,16 @@ class Compiler(scalac: AnalyzingCompiler, javac: JavaCompiler) {
 
   /**
    * Run a compile. The resulting analysis is also cached in memory.
+   *
+   *  Note:  This variant automatically contructs an error-reporter
+   *         using given maxErrors and sourcePositionMapper parameters.
+   */
+  def compile(inputs: Inputs, cwd: Option[File], maxErrors: java.lang.Integer, sourcePositionMapper: xsbti.Position => xsbti.Position)(log: Logger): Analysis = {
+    compile(inputs, cwd, new LoggerReporter(maxErrors, log, sourcePositionMapper))(log)
+  }
+
+  /**
+   * Run a compile. The resulting analysis is also cached in memory.
    * 
    *  Note: This variant does not report progress updates
    */


### PR DESCRIPTION
This is small improvement.

Having two input parameters: `maximumErrors` and `sourcePositionMapper`, I'd like to simplify `Compiler.compile` call in my Java code:
```scala
Reporter reporter =
    new sbt.LoggerReporter( maximumErrors, sbt.Logger$.MODULE$.xlog2Log( sbtLogger ), sourcePositionMapper );
compiler.compile( inputs, Option.<File> empty(), reporter, sbtLogger );
```
with simpler version:
```scala
compiler.compile( inputs, Option.<File> empty(), maximumErrors, sourcePositionMapper, sbtLogger );
```